### PR TITLE
Install as a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Officially supported transitions plugin for [Svelte](https://svelte.technology).
 Install with npm or yarn:
 
 ```bash
-npm install --save svelte-transitions
+npm install --save-dev svelte-transitions
 ```
 
 Then add the plugins you need to your Svelte component's exported definition:


### PR DESCRIPTION
I think in most cases this belongs as a dev dependency, the same as svelte in the template https://github.com/sveltejs/template/blob/master/package.json#L12